### PR TITLE
OF-v2012

### DIFF
--- a/of70/src/libs/gaussDefCmpwConvectionScheme/gaussDefCmpwConvectionScheme.H
+++ b/of70/src/libs/gaussDefCmpwConvectionScheme/gaussDefCmpwConvectionScheme.H
@@ -92,7 +92,7 @@ public:
         (
             const fvMesh& mesh,
             const surfaceScalarField& faceFlux,
-            const word& scheme
+            Istream& scheme
         )
         :
             convectionScheme<Type>(mesh, faceFlux),
@@ -105,7 +105,8 @@ public:
             const fvMesh& mesh,
             const surfaceScalarField& faceFlux,
             Istream& is,
-            const word& scheme
+            Istream& scheme
+            // remove triSurface in Make/options for OF-v2012
         )
         :
             convectionScheme<Type>(mesh, faceFlux),


### PR DESCRIPTION
我用的OpenFOAM是v2212，即，从这里安装的https://github.com/gerlero/openfoam-app
然后下载您这里的rheTool在我的mac （macos Monterey v12.6.3）上安装。
安装出现错误，提示如下：
================================================================================
TEST configureDirectories from PETSc.options.petscdir(/Users/pfg/OpenFOAM/pfg-v2212/ThirdParty/petsc-3.14.5/config/PETSc/options/petscdir.py:23)
TESTING: configureDirectories from PETSc.options.petscdir(config/PETSc/options/petscdir.py:23)
  Checks PETSC_DIR and sets if not set
*******************************************************************************
         UNABLE to CONFIGURE with GIVEN OPTIONS    (see configure.log for details):
-------------------------------------------------------------------------------
The environmental variable PETSC_DIR /usr/local/Cellar/petsc/3.15.4 MUST be the current directory /Users/pfg/OpenFOAM/pfg-v2212/ThirdParty/petsc-3.14.5
非常愿意有偿帮助，我的qq：254679746
谢谢您！