### PR TITLE
Add Oldroyd-A model (standard and log-conformation)

### DIFF
--- a/of90/src/libs/constitutiveEquations/Make/files
+++ b/of90/src/libs/constitutiveEquations/Make/files
@@ -7,6 +7,9 @@ constitutiveEqs/constitutiveEq/newConstitutiveEq.C
  constitutiveEqs/Oldroyd-B/Oldroyd-BLog/Oldroyd_BLog.C
  constitutiveEqs/Oldroyd-B/Oldroyd-BSqrt/Oldroyd_BSqrt.C
  constitutiveEqs/Oldroyd-B/Oldroyd-BRootk/Oldroyd_BRootk.C
+
+ constitutiveEqs/Oldroyd-A/Oldroyd_A.C
+ constitutiveEqs/Oldroyd-A/Oldroyd-ALog/Oldroyd_ALog.C
  
  constitutiveEqs/Giesekus/Giesekus.C
  constitutiveEqs/Giesekus/GiesekusLog/GiesekusLog.C

--- a/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd-ALog/Oldroyd_ALog.C
+++ b/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd-ALog/Oldroyd_ALog.C
@@ -1,0 +1,172 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright held by original author
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+\*---------------------------------------------------------------------------*/
+
+#include "Oldroyd_ALog.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace constitutiveEqs 
+{
+    defineTypeNameAndDebug(Oldroyd_ALog, 0);
+    addToRunTimeSelectionTable(constitutiveEq, Oldroyd_ALog, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::constitutiveEqs::Oldroyd_ALog::Oldroyd_ALog
+(
+    const word& name,
+    const volVectorField& U,
+    const surfaceScalarField& phi,
+    const dictionary& dict
+)
+:
+    constitutiveEq(name, U, phi),
+    tau_
+    (
+        IOobject
+        (
+            "tau" + name,
+            U.time().timeName(),
+            U.mesh(),
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE
+        ),
+        U.mesh()
+    ),
+    theta_
+    (
+        IOobject
+        (
+            "theta" + name,
+            U.time().timeName(),
+            U.mesh(),
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE
+        ),
+        U.mesh()
+    ),
+    eigVals_
+    (
+        IOobject
+        (
+            "eigVals" + name,
+            U.time().timeName(),
+            U.mesh(),
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        U.mesh(),
+        dimensionedTensor
+        (
+                "I",
+                dimless,
+                pTraits<tensor>::I
+        ),
+         extrapolatedCalculatedFvPatchField<tensor>::typeName
+    ),
+    eigVecs_
+    (
+        IOobject
+        (
+            "eigVecs" + name,
+            U.time().timeName(),
+            U.mesh(),
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
+        ),
+        U.mesh(),
+        dimensionedTensor
+        (
+                "I",
+                dimless,
+                pTraits<tensor>::I
+        ),
+         extrapolatedCalculatedFvPatchField<tensor>::typeName
+    ),
+    rho_(dict.lookup("rho")),
+    etaS_(dict.lookup("etaS")),
+    etaP_(dict.lookup("etaP")),
+    lambda_(dict.lookup("lambda")),
+    thermoLambdaPtr_(thermoFunction::New("thermoLambda", U.mesh(), dict)),  
+    thermoEtaPtr_(thermoFunction::New("thermoEta", U.mesh(), dict))  
+{
+ checkForStab(dict);
+}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+
+void Foam::constitutiveEqs::Oldroyd_ALog::correct
+(
+  const volScalarField* alpha,
+  const volTensorField* gradU
+)
+{
+    // Update params thermo 
+    volScalarField lambda(thermoLambdaPtr_->createField(lambda_));
+    volScalarField etaP(thermoEtaPtr_->createField(etaP_));
+    
+    // Decompose grad(U).T()
+    #include "boilerLog.H" 
+		// Correct transformation grad(U).T() = Omega' - B' + inv(theta_) & N'
+		decomposeGradU(-M.T(), eigVals_, eigVecs_, omega, B);
+  
+    // Solve the constitutive Eq in theta = log(c)
+    fvSymmTensorMatrix thetaEqn
+    (
+         fvm::ddt(theta_)
+       + fvm::div(phi(), theta_)
+       ==
+       symm
+       (  
+         (omega&theta_)
+       - (theta_&omega)
+       + 2.0 * B
+       + (1.0/lambda)  * innerP(eigVecs_,(inv(eigVals_)-Itensor),false)
+       )       
+    );     
+      
+   thetaEqn.relax();
+   thetaEqn.solve();
+    
+   // Diagonalization of theta
+
+   calcEig(theta_, eigVals_, eigVecs_);
+
+   // Convert from theta to tau
+   tau_ = (etaP/lambda) * symm( Itensor - innerP(eigVecs_,eigVals_,false) );
+   
+
+   tau_.correctBoundaryConditions();
+}
+
+
+// ************************************************************************* //

--- a/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd-ALog/Oldroyd_ALog.H
+++ b/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd-ALog/Oldroyd_ALog.H
@@ -1,0 +1,190 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright held by original author
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+Class
+    Oldroyd_ALog
+    
+SourceFiles
+    Oldroyd_ALog.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef Oldroyd_ALog_H
+#define Oldroyd_ALog_H
+
+#include "constitutiveEq.H"
+#include "thermoFunction.H"  
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace constitutiveEqs
+{ 
+
+/*---------------------------------------------------------------------------*\
+                           Class Oldroyd_ALog Declaration
+\*---------------------------------------------------------------------------*/
+
+class Oldroyd_ALog
+:
+    public constitutiveEq
+{
+    // Private data
+
+        //- Transported viscoelastic stress
+        volSymmTensorField tau_;
+
+        //- Logarithm of the conformation tensor
+        volSymmTensorField theta_;
+ 
+        //- Eigenvalues of theta diagonalization (values on the tensor diagonal)
+        volTensorField eigVals_;
+
+        //- Eigenvectors of theta diagonalization
+        volTensorField eigVecs_;
+ 
+        // Model constants
+
+            //- Density
+            dimensionedScalar rho_;
+
+            //- Solvent viscosity
+            dimensionedScalar etaS_;
+
+            //- Zero shear rate polymer viscosity
+            dimensionedScalar etaP_;
+
+            //- Relaxation time
+            dimensionedScalar lambda_;
+            
+            //- Thermofunction for temperature dependence of lambda
+            autoPtr<thermoFunction> thermoLambdaPtr_;
+        
+            //- Thermofunction for temperature dependence of viscosity
+            autoPtr<thermoFunction> thermoEtaPtr_;
+ 
+
+    // Private Member Functions
+
+        //- Disallow default bitwise copy construct
+        Oldroyd_ALog(const Oldroyd_ALog&);
+
+        //- Disallow default bitwise assignment
+        void operator=(const Oldroyd_ALog&);
+        
+protected:
+
+       //- Return the solvent viscosity
+       virtual const dimensionedScalar etaS() const
+       {
+          return etaS_;
+       }
+      
+       //- Return the polymeric viscosity
+       virtual const dimensionedScalar etaP() const
+       {
+          return etaP_;
+       }
+       
+       // Return etaS corrected for temperature
+       virtual tmp<volScalarField> etaSThermo() const
+       {
+          return thermoEtaPtr_->createField(etaS_);
+       }
+       
+       // Return etaP corrected for temperature
+       virtual tmp<volScalarField> etaPThermo() const
+       {
+          return thermoEtaPtr_->createField(etaP_);
+       }
+       
+       // Is the model prepared to work in non-isothermal conditions
+       virtual bool hasThermo() const
+       {
+         return true;
+       }
+ 
+public:
+
+    //- Runtime type information
+    TypeName("Oldroyd-ALog");
+
+    // Constructors
+
+        //- Construct from components
+        Oldroyd_ALog
+        (
+            const word& name,
+            const volVectorField& U,
+            const surfaceScalarField& phi,
+            const dictionary& dict
+        );
+
+
+    // Destructor
+
+        virtual ~Oldroyd_ALog()
+        {}
+
+
+    // Member Functions
+
+       //- Return the viscoelastic stress tensor
+        virtual tmp<volSymmTensorField> tau() const
+        {
+            return tau_;
+        }
+        
+        //- Return the density
+        virtual const dimensionedScalar rho() const
+        {
+            return rho_;
+        }
+         
+        //- Return true if GNF (non-elastic)
+        virtual bool isGNF() const
+        {
+          return false;
+        };
+
+        //- Correct the viscoelastic stress: alpha is the color function in two phase-flows
+        virtual void correct
+        (
+          const volScalarField* alpha = nullptr,
+          const volTensorField* gradU = nullptr
+        );
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace constitutiveEqs 
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd_A.C
+++ b/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd_A.C
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright held by original author
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+\*---------------------------------------------------------------------------*/
+
+#include "coupledSolver.H" 
+#include "blockOperators.H" 
+#include "Oldroyd_A.H"
+#include "addToRunTimeSelectionTable.H"
+
+// * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace constitutiveEqs 
+{
+    defineTypeNameAndDebug(Oldroyd_A, 0);
+    addToRunTimeSelectionTable(constitutiveEq, Oldroyd_A, dictionary);
+}
+}
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+
+Foam::constitutiveEqs::Oldroyd_A::Oldroyd_A
+(
+    const word& name,
+    const volVectorField& U,
+    const surfaceScalarField& phi,
+    const dictionary& dict
+)
+:
+    constitutiveEq(name, U, phi),
+    tau_
+    (
+        IOobject
+        (
+            "tau" + name,
+            U.time().timeName(),
+            U.mesh(),
+            IOobject::MUST_READ,
+            IOobject::AUTO_WRITE
+        ),
+        U.mesh()
+    ),
+    rho_(dict.lookup("rho")),
+    etaS_(dict.lookup("etaS")),
+    etaP_(dict.lookup("etaP")),
+    lambda_(dict.lookup("lambda")),
+    thermoLambdaPtr_(thermoFunction::New("thermoLambda", U.mesh(), dict)),  
+    thermoEtaPtr_(thermoFunction::New("thermoEta", U.mesh(), dict))  
+{
+ checkForStab(dict);
+ 
+ checkIfCoupledSolver(U.mesh().solutionDict(), tau_); 
+}
+
+
+// * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
+ 
+void Foam::constitutiveEqs::Oldroyd_A::correct
+(
+  const volScalarField* alpha,
+  const volTensorField* gradU
+)
+{
+ // Update temperature-dependent properties
+ volScalarField lambda(thermoLambdaPtr_->createField(lambda_));
+ volScalarField etaP(thermoEtaPtr_->createField(etaP_));
+ 
+ // Velocity gradient tensor
+ volTensorField L(gradU == nullptr ? fvc::grad(U())() : *gradU);
+
+ // Convected derivate term
+ volTensorField C(L & tau_);
+
+ // Twice the rate of deformation tensor
+ volSymmTensorField twoD(twoSymm(L));
+
+ // Stress transport equation
+ fvSymmTensorMatrix tauEqn
+ (
+    fvm::ddt(tau_)
+  + fvm::div(phi(), tau_) 
+  ==
+  - twoSymm(C)
+  - fvm::Sp(1/lambda, tau_)
+ );
+ 
+ tauEqn.relax();
+    
+ if (!solveCoupled_)
+ { 
+   solve(tauEqn == etaP/lambda*twoD);   
+ }
+ else
+ {   
+   // Get the solver
+   coupledSolver& cps = U().time().lookupObjectRef<coupledSolver>( word("Uptau." + U().mesh().name()) ); 
+      
+   // Insert tauEqn
+   cps.insertEquation
+   (
+     tau_.name(),
+     tau_.name(),
+     tauEqn
+   );
+
+   // Insert term (gradU + gradU.T)
+   cps.insertEquation
+   (
+     tau_.name(),
+     U().name(),
+     fvmb::twoSymmGrad(-etaP/lambda, U())
+   );   
+ } 
+}
+
+// ************************************************************************* //

--- a/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd_A.H
+++ b/of90/src/libs/constitutiveEquations/constitutiveEqs/Oldroyd-A/Oldroyd_A.H
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright held by original author
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software; you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by the
+    Free Software Foundation; either version 2 of the License, or (at your
+    option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+
+Class
+    Oldroyd_A
+
+SourceFiles
+    Oldroyd_A.C
+
+\*---------------------------------------------------------------------------*/
+
+#ifndef Oldroyd_A_H
+#define Oldroyd_A_H
+
+#include "constitutiveEq.H"
+#include "thermoFunction.H" 
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+namespace constitutiveEqs
+{ 
+
+/*---------------------------------------------------------------------------*\
+                           Class Oldroyd_A Declaration
+\*---------------------------------------------------------------------------*/
+
+class Oldroyd_A
+:
+    public constitutiveEq
+{
+    // Private data
+
+        //- Transported viscoelastic stress
+        volSymmTensorField tau_;
+
+        // Model constants
+
+            //- Density
+            dimensionedScalar rho_;
+
+            //- Solvent viscosity
+            dimensionedScalar etaS_;
+
+            //- Zero shear rate polymer viscosity
+            dimensionedScalar etaP_;
+
+            //- Relaxation time
+            dimensionedScalar lambda_;
+            
+            //- Thermofunction for temperature dependence of lambda
+            autoPtr<thermoFunction> thermoLambdaPtr_;
+        
+            //- Thermofunction for temperature dependence of viscosity
+            autoPtr<thermoFunction> thermoEtaPtr_;
+ 
+    // Private Member Functions
+
+        //- Disallow default bitwise copy construct
+        Oldroyd_A(const Oldroyd_A&);
+
+        //- Disallow default bitwise assignment
+        void operator=(const Oldroyd_A&);
+        
+protected:
+
+       //- Return the solvent viscosity
+       virtual const dimensionedScalar etaS() const
+       {
+          return etaS_;
+       }
+      
+       //- Return the polymeric viscosity
+       virtual const dimensionedScalar etaP() const
+       {
+          return etaP_;
+       }
+       
+       // Return etaS corrected for temperature
+       virtual tmp<volScalarField> etaSThermo() const
+       {
+          return thermoEtaPtr_->createField(etaS_);
+       }
+       
+       // Return etaP corrected for temperature
+       virtual tmp<volScalarField> etaPThermo() const
+       {
+          return thermoEtaPtr_->createField(etaP_);
+       }
+       
+       // Is the model prepared to work in non-isothermal conditions
+       virtual bool hasThermo() const
+       {
+         return true;
+       }
+ 
+public:
+
+    //- Runtime type information
+    TypeName("Oldroyd-A");
+
+    // Constructors
+
+        //- Construct from components
+        Oldroyd_A
+        (
+            const word& name,
+            const volVectorField& U,
+            const surfaceScalarField& phi,
+            const dictionary& dict
+        );
+
+
+    // Destructor
+
+        virtual ~Oldroyd_A()
+        {}
+
+
+    // Member Functions
+
+        //- Return the viscoelastic stress tensor
+        virtual tmp<volSymmTensorField> tau() const
+        {
+            return tau_;
+        }
+        
+        //- Return the density
+        virtual const dimensionedScalar rho() const
+        {
+            return rho_;
+        }
+          
+        //- Return true if GNF (non-elastic)
+        virtual bool isGNF() const
+        {
+          return false;
+        };
+
+        //- Correct the viscoelastic stress: alpha is the color function in two phase-flows
+        virtual void correct
+        (
+          const volScalarField* alpha = nullptr,
+          const volTensorField* gradU = nullptr
+        );
+};
+
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace constitutiveEqs 
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //


### PR DESCRIPTION
I am creating this pull request primarily for people interested in this model.
In particular, this adds the Oldroyd-A model for of90 using the standard form `Oldroyd_A` and the log conformation `Oldroyd_ALog`.

I did not bother with other conformations, such as square-root or root-k out of frankly lazyness but they should not be hard to add. This also does not add tutorials, though I did test it for the cavity at the time I wrote the code. The code may also not be formatted correctly, so let me know if you want me to change/check it.

If need be, I can supplement the missing parts but more exhaustive testing should be done anyway before merging.